### PR TITLE
Scala 2.12.0-M5 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,12 @@
 import ReleaseTransformations._
+import sbt._
 
 val buildSettings = Seq[Setting[_]](
   scalaVersion := "2.11.8",
+  crossScalaVersions := Seq(
+    "2.11.8",
+    "2.12.0-M5"
+  ),
   organization := "org.wvlet",
   crossPaths := true,
   publishMavenStyle := true,
@@ -62,6 +67,6 @@ lazy val wvletLog =
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "ch.qos.logback" % "logback-core" % "1.1.7",
-      "org.scalatest" %% "scalatest" % "2.2.+" % "test"
+      "org.scalatest" %% "scalatest" % "3.0.0" % "test"
     )
   )

--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,11 @@ dependencies:
   pre:
     - ./sbt sbt-version
   override:
-    - ./sbt compile
+    - ./sbt "+ test:compile"
 
 test:
   override:
-    - ./sbt coverage test coverageReport && ./sbt coverageAggregate
-  post:
-    - ./sbt coveralls
+    - ./sbt "+ test"
+#   - ./sbt coverage test coverageReport && ./sbt coverageAggregate
+#  post:
+#    - ./sbt coveralls

--- a/project/build.properties
+++ b/project/build.properties
@@ -12,4 +12,4 @@
 # limitations under the License.
 #
 
-sbt.version=0.13.9
+sbt.version=0.13.12

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+// sbt-scoverage doesn't work for Scala 2.12.0
+//addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+//addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/src/test/scala/wvlet/log/Spec.scala
+++ b/src/test/scala/wvlet/log/Spec.scala
@@ -3,6 +3,6 @@ package wvlet.log
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, WordSpec, _}
 import wvlet.log.LogFormatter.SourceCodeLogFormatter
 
-trait Spec extends WordSpec with ShouldMatchers with BeforeAndAfter with BeforeAndAfterAll with LogSupport {
+trait Spec extends WordSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll with LogSupport {
   logger.resetHandler(new ConsoleLogHandler(SourceCodeLogFormatter))
 }


### PR DESCRIPTION
- [x] Upgrade to sbt 0.13.12
- [x] Upgrade to scalatest 3.0.0 to support both Scala 2.11 and 2.12
- [x] Disable sbt-scoverage plugin, which doesn't support Scala 2.12
